### PR TITLE
fix #58 #68

### DIFF
--- a/rpg2d2/Assets/Resources/Scripts/BattleManager.cs
+++ b/rpg2d2/Assets/Resources/Scripts/BattleManager.cs
@@ -153,7 +153,7 @@ public class BattleManager : MonoBehaviour
     }
     public static void ToggleCommands()
     {
-        
+
         if (GameObject.Find("Commands") != null)
         {
             GameObject.Find("Commands").SetActive(false);
@@ -219,16 +219,18 @@ public class BattleManager : MonoBehaviour
             e_damage = (int)(EnemyController.enemy_status["at"] * UnityEngine.Random.Range(0.6f, 1.5f)) + UnityEngine.Random.Range(1, EnemyController.enemy_status["ag"]);
             tsukon = true;
         }
-
-        if (EnemyController.enemy_status["at"] - PlayerContoroller.player_status["df"] > 0)
-        {
-            e_damage = (int)(EnemyController.enemy_status["at"] - PlayerContoroller.player_status["df"] * UnityEngine.Random.Range(0.6f, 1.5f)) + UnityEngine.Random.Range(1, EnemyController.enemy_status["ag"]);
-        }
         else
         {
-            e_damage = (int)(UnityEngine.Random.Range(1, 3) * UnityEngine.Random.Range(0.6f, 1.5f));
-        }
 
+            if (EnemyController.enemy_status["at"] - PlayerContoroller.player_status["df"] > 0)
+            {
+                e_damage = (int)(EnemyController.enemy_status["at"] - PlayerContoroller.player_status["df"] * UnityEngine.Random.Range(0.6f, 1.5f)) + UnityEngine.Random.Range(1, EnemyController.enemy_status["ag"]);
+            }
+            else
+            {
+                e_damage = (int)(UnityEngine.Random.Range(1, 3) * UnityEngine.Random.Range(0.6f, 1.5f));
+            }
+        }
         return new IntAndBool()
         {
             damage = e_damage,
@@ -299,7 +301,7 @@ public class BattleManager : MonoBehaviour
                 PlayerContoroller.player_status["mdf"] += StatusData.LvupPlayerStatus[i, 4];
                 PlayerContoroller.player_status["mag"] += StatusData.LvupPlayerStatus[i, 5];
                 StatusUpdate();
-                
+
                 LogController.Callback callback;//メッセージ表示後実行する関数
                 if (Check_drop())
                 {
@@ -352,4 +354,3 @@ public class BattleManager : MonoBehaviour
         SceneManager.LoadScene("Scene/" + SceneManager2d.current_scene);
     }
 }
- 

--- a/rpg2d2/Assets/Resources/Scripts/EncountController.cs
+++ b/rpg2d2/Assets/Resources/Scripts/EncountController.cs
@@ -20,7 +20,6 @@ public class EncountController : MonoBehaviour {
         m_fade.alfa = 0;
         m_fade.isFadeOut = true;
         player.GetComponent<Animator>().enabled = false;
-        player.name = "Player_used";
     }
 
 
@@ -35,7 +34,7 @@ public class EncountController : MonoBehaviour {
 
 	public void InsertBattleScene()
 	{
-		SceneManager.LoadScene("Scene/battle");
+        GameObject.Find("GameManager").GetComponent<GameManager>().SceneChange("battle");
 	}
 		
 }

--- a/rpg2d2/Assets/Resources/Scripts/GameManager.cs
+++ b/rpg2d2/Assets/Resources/Scripts/GameManager.cs
@@ -1,0 +1,202 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.SceneManagement;
+using System;
+
+public class GameManager : MonoBehaviour
+{
+
+    Dictionary<string, bool> strongBoxes;
+    bool isStateShow = false;
+
+    // Use this for initialization
+    void Start()
+    {
+        if (GameObject.Find("GameManager") != gameObject)
+        {
+            Destroy(gameObject);
+        }
+        else
+        {
+            DontDestroyOnLoad(this);
+        }
+        strongBoxes = new Dictionary<string, bool>();
+        SceneManager.sceneLoaded += OnSceneLoaded;
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+    }
+
+    public void SceneChange(string sceneName)
+    {
+        OnSceneUnloaded(SceneManager.GetActiveScene());
+        SceneManager.LoadScene("Scene/" + sceneName);
+    }
+
+    public void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        if (scene.name != "battle" && scene.name != "title")
+        {
+            GameObject.Find("Player").GetComponent<Animator>().enabled = true;
+            if (isStateShow)
+            {
+                GameObject.Find("Window").transform.Find("StatusWindow").gameObject.SetActive(true);
+                GameObject.Find("MenuWindow").transform.Find("MenuButtons").transform.Find("Status").GetComponentInChildren<Text>().text = "ステータスを非表示";
+            }
+            foreach (GameObject strongBox in GameObject.FindGameObjectsWithTag("StrongBox"))
+            {
+                if (strongBoxes.ContainsKey(strongBox.name))
+                {
+                    strongBox.GetComponent<OpenBoxContoroller>().isOpen = strongBoxes[strongBox.name];
+                }
+            }
+        }
+    }
+
+    public void OnSceneUnloaded(Scene scene)
+    {
+        if (scene.name != "battle" && scene.name != "title")
+        {
+            isStateShow = GameObject.Find("StatusWindow") != null;
+            foreach (GameObject strongBox in GameObject.FindGameObjectsWithTag("StrongBox"))
+            {
+                if (strongBoxes.ContainsKey(strongBox.name))
+                {
+                    strongBoxes[strongBox.name] = strongBox.GetComponent<OpenBoxContoroller>().isOpen;
+                }
+                else
+                {
+                    strongBoxes.Add(strongBox.name, strongBox.GetComponent<OpenBoxContoroller>().isOpen);
+                }
+            }
+        }
+    }
+
+    public void Save()
+    {
+        OnSceneUnloaded(SceneManager.GetActiveScene());
+
+        string player_status = JsonUtility.ToJson(new Serialization<string, int>(PlayerContoroller.player_status), true);
+        string player_position = JsonUtility.ToJson(GameObject.Find("Player").GetComponent<Transform>().position, true);
+        string my_items = JsonUtility.ToJson(new Serialization<int>(PlayerContoroller.my_items), true);
+        string player_name = PlayerContoroller.player_name;
+        string scene_name = SceneManager.GetActiveScene().name;
+        string statusWindow = isStateShow.ToString();
+        string strongBoxStatus = JsonUtility.ToJson(new Serialization<string, bool>(strongBoxes), true);
+        Dictionary<string, string> data = new Dictionary<string, string>();
+        data.Add("player_status", player_status);
+        data.Add("player_position", player_position);
+        data.Add("player_name", player_name);
+        data.Add("scene_name", scene_name);
+        data.Add("my_items", my_items);
+        data.Add("strongBoxes", strongBoxStatus);
+        data.Add("isStateShow", statusWindow);
+
+        string json = JsonUtility.ToJson(new Serialization<string, string>(data), true);
+        PlayerPrefs.SetString("save", json);
+    }
+
+    public void Load()
+    {
+        string json = PlayerPrefs.GetString("save");
+        Dictionary<string, string> data = JsonUtility.FromJson<Serialization<string, string>>(json).ToDictionary();
+
+        Dictionary<string, int> player_status = new Dictionary<string, int>();
+        Vector3 player_position = Vector3.zero;
+        string player_name = "";
+        string scene_name = "";
+        List<int> my_items = new List<int>();
+
+        foreach (string key in data.Keys)
+        {
+            switch (key)
+            {
+                case "player_status":
+                    player_status = JsonUtility.FromJson<Serialization<string, int>>(data[key]).ToDictionary();
+                    break;
+                case "player_position":
+                    player_position = JsonUtility.FromJson<Vector3>(data[key]);
+                    break;
+                case "player_name":
+                    player_name = data[key];
+                    break;
+                case "scene_name":
+                    scene_name = data[key];
+                    break;
+                case "my_items":
+                    my_items = JsonUtility.FromJson<Serialization<int>>(data[key]).ToList();
+                    break;
+                case "strongBoxes":
+                    strongBoxes = JsonUtility.FromJson<Serialization<string, bool>>(data[key]).ToDictionary();
+                    break;
+                case "isStateShow":
+                    if (data[key] == "True")
+                    {
+                        isStateShow = true;
+                    }
+                    else
+                    {
+                        isStateShow = false;
+                    }
+                    break;
+            }
+        }
+        PlayerContoroller.player_status = player_status;
+        PlayerContoroller.player_name = player_name;
+        PlayerContoroller.my_items = my_items;
+        GameObject.Find("Player").GetComponent<Transform>().position = player_position;
+        SceneChange(scene_name);
+    }
+
+    // List<T>
+    [Serializable]
+    public class Serialization<T>
+    {
+        [SerializeField]
+        List<T> target;
+        public List<T> ToList() { return target; }
+
+        public Serialization(List<T> target)
+        {
+            this.target = target;
+        }
+    }
+
+    // Dictionary<TKey, TValue>
+    [Serializable]
+    public class Serialization<TKey, TValue> : ISerializationCallbackReceiver
+    {
+        [SerializeField]
+        List<TKey> keys;
+        [SerializeField]
+        List<TValue> values;
+
+        Dictionary<TKey, TValue> target;
+        public Dictionary<TKey, TValue> ToDictionary() { return target; }
+
+        public Serialization(Dictionary<TKey, TValue> target)
+        {
+            this.target = target;
+        }
+
+        public void OnBeforeSerialize()
+        {
+            keys = new List<TKey>(target.Keys);
+            values = new List<TValue>(target.Values);
+        }
+
+        public void OnAfterDeserialize()
+        {
+            var count = Math.Min(keys.Count, values.Count);
+            target = new Dictionary<TKey, TValue>(count);
+            for (var i = 0; i < count; ++i)
+            {
+                target.Add(keys[i], values[i]);
+            }
+        }
+    }
+}

--- a/rpg2d2/Assets/Resources/Scripts/GameManager.cs.meta
+++ b/rpg2d2/Assets/Resources/Scripts/GameManager.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 56d5a2e722320f946b5347fa0d693507
+timeCreated: 1508560856
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/rpg2d2/Assets/Resources/Scripts/MenuController.cs
+++ b/rpg2d2/Assets/Resources/Scripts/MenuController.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.SceneManagement;
-using System;
 
 public class MenuController : MonoBehaviour
 {
@@ -22,21 +21,20 @@ public class MenuController : MonoBehaviour
 
     private static void CloseItemList()
     {
-        GameObject.Find("Description").GetComponentInChildren<Text>().text = "";
-        GameObject.Find("ItemImage").GetComponent<Image>().sprite = null;
-        GameObject.Find("ItemList").SetActive(false);
-        GameObject.Find("Items").GetComponentInChildren<Text>().text = "どうぐ";
+        if (GameObject.Find("ItemList") != null)
+        {
+            GameObject.Find("Description").GetComponentInChildren<Text>().text = "";
+            GameObject.Find("ItemImage").GetComponent<Image>().sprite = null;
+            GameObject.Find("ItemList").SetActive(false);
+            GameObject.Find("Items").GetComponentInChildren<Text>().text = "どうぐ";
+        }
     }
 
     public static void CloseMenu()
     {
-
         if (GameObject.Find("MenuButtons") != null)
         {
-            if (GameObject.Find("ItemList") != null)
-            {
-                CloseItemList();
-            }
+            CloseItemList();
             GameObject.Find("MenuWindow").GetComponent<RectTransform>().sizeDelta = new Vector2(200, 50);
             GameObject.Find("MenuButtons").SetActive(false);
             GameObject.Find("Menu").GetComponentInChildren<Text>().text = "メニュー";
@@ -45,7 +43,7 @@ public class MenuController : MonoBehaviour
 
     public void Menu()
     {
-        if(GameObject.Find("MenuButtons") != null)
+        if (GameObject.Find("MenuButtons") != null)
         {
             CloseMenu();
         }
@@ -111,87 +109,17 @@ public class MenuController : MonoBehaviour
 
     public void Save()
     {
-        string player_status = JsonUtility.ToJson(new Serialization<string,int>(PlayerContoroller.player_status),true);
-        string player_position = JsonUtility.ToJson(GameObject.Find("Player").GetComponent<Transform>().position, true);
-        string my_items = JsonUtility.ToJson(new Serialization<int>(PlayerContoroller.my_items), true);
-        string player_name = PlayerContoroller.player_name;
-        string scene_name = SceneManager.GetActiveScene().name;
-        Dictionary<string, string> data = new Dictionary<string, string>();
-        data.Add("player_status", player_status);
-        data.Add("player_position", player_position);
-        data.Add("player_name", player_name);
-        data.Add("scene_name", scene_name);
-        data.Add("my_items", my_items);
-
-        string json = JsonUtility.ToJson(new Serialization<string, string>(data),true);
-        PlayerPrefs.SetString("save", json);
         GameObject.Find("MenuWindow").GetComponent<RectTransform>().sizeDelta = new Vector2(200, 50);
         GameObject.Find("MenuButtons").SetActive(false);
         GameObject.Find("Menu").GetComponentInChildren<Text>().text = "メニュー";
-        if (GameObject.Find("ItemList") != null)
-        {
-            GameObject.Find("ItemList").SetActive(false);
-        }
+        CloseItemList();
+        GameObject.Find("GameManager").GetComponent<GameManager>().Save();
         GameObject.Find("Window").transform.Find("LogWindow").gameObject.SetActive(true);
         GameObject.Find("LogWindow").GetComponent<LogController>().printText(new string[] { "セーブしました。" });
     }
 
-    // List<T>
-    [Serializable]
-    public class Serialization<T>
-    {
-        [SerializeField]
-        List<T> target;
-        public List<T> ToList() { return target; }
-
-        public Serialization(List<T> target)
-        {
-            this.target = target;
-        }
-    }
-
-    // Dictionary<TKey, TValue>
-    [Serializable]
-    public class Serialization<TKey, TValue> : ISerializationCallbackReceiver
-    {
-        [SerializeField]
-        List<TKey> keys;
-        [SerializeField]
-        List<TValue> values;
-
-        Dictionary<TKey, TValue> target;
-        public Dictionary<TKey, TValue> ToDictionary() { return target; }
-
-        public Serialization(Dictionary<TKey, TValue> target)
-        {
-            this.target = target;
-        }
-
-        public void OnBeforeSerialize()
-        {
-            keys = new List<TKey>(target.Keys);
-            values = new List<TValue>(target.Values);
-        }
-
-        public void OnAfterDeserialize()
-        {
-            var count = Math.Min(keys.Count, values.Count);
-            target = new Dictionary<TKey, TValue>(count);
-            for (var i = 0; i < count; ++i)
-            {
-                target.Add(keys[i], values[i]);
-            }
-        }
-    }
-
     public void End()
     {
-        #if UNITY_EDITOR
-			UnityEditor.EditorApplication.isPlaying = false;
-        #elif UNITY_WEBPLAYER
-			Application.OpenURL("http://www.yahoo.co.jp/");
-        #else
-            Application.Quit();
-        #endif
+        GameObject.Find("GameManager").GetComponent<GameManager>().SceneChange("title");
     }
 }

--- a/rpg2d2/Assets/Resources/Scripts/MenuController.cs
+++ b/rpg2d2/Assets/Resources/Scripts/MenuController.cs
@@ -109,17 +109,38 @@ public class MenuController : MonoBehaviour
 
     public void Save()
     {
-        GameObject.Find("MenuWindow").GetComponent<RectTransform>().sizeDelta = new Vector2(200, 50);
-        GameObject.Find("MenuButtons").SetActive(false);
-        GameObject.Find("Menu").GetComponentInChildren<Text>().text = "メニュー";
-        CloseItemList();
-        GameObject.Find("GameManager").GetComponent<GameManager>().Save();
-        GameObject.Find("Window").transform.Find("LogWindow").gameObject.SetActive(true);
-        GameObject.Find("LogWindow").GetComponent<LogController>().printText(new string[] { "セーブしました。" });
+        if (GameObject.Find("GameManager") != null)
+        {
+            CloseItemList();
+            GameObject.Find("MenuWindow").GetComponent<RectTransform>().sizeDelta = new Vector2(200, 50);
+            GameObject.Find("MenuButtons").SetActive(false);
+            GameObject.Find("Menu").GetComponentInChildren<Text>().text = "メニュー";
+            GameObject.Find("GameManager").GetComponent<GameManager>().Save();
+            GameObject.Find("Window").transform.Find("LogWindow").gameObject.SetActive(true);
+            GameObject.Find("LogWindow").GetComponent<LogController>().printText(new string[] { "セーブしました。" });
+        }
+        else
+        {
+            GameObject.Find("Window").transform.Find("LogWindow").gameObject.SetActive(true);
+            GameObject.Find("LogWindow").GetComponent<LogController>().printText(new string[] { "タイトルから実行するとセーブできます。別にしようとすればできるけどね" });
+        }
     }
 
     public void End()
     {
-        GameObject.Find("GameManager").GetComponent<GameManager>().SceneChange("title");
+        if (GameObject.Find("GameManager") != null)
+        {
+            GameObject.Find("GameManager").GetComponent<GameManager>().SceneChange("title");
+        }
+        else
+        {
+            #if UNITY_EDITOR
+                UnityEditor.EditorApplication.isPlaying = false;
+            #elif UNITY_WEBPLAYER
+			    Application.OpenURL("http://www.yahoo.co.jp/");
+            #else
+			    Application.Quit();
+            #endif
+        }
     }
 }

--- a/rpg2d2/Assets/Resources/Scripts/OpenBoxContoroller.cs
+++ b/rpg2d2/Assets/Resources/Scripts/OpenBoxContoroller.cs
@@ -6,11 +6,18 @@ public class OpenBoxContoroller : MonoBehaviour {
 
 	public int item_id = 1;
 	private Sprite[] sp;
-    private bool isOpen;
+    public bool isOpen = false;
 
     void Start(){
 		sp = Resources.LoadAll<Sprite>("Sprites/juelBox");
-        isOpen = false;
+        if (isOpen)
+        {
+            GetComponent<SpriteRenderer>().sprite = sp[1];
+        }
+        else
+        {
+            GetComponent<SpriteRenderer>().sprite = sp[0];
+        }
     }
 
 	public void OpenBox(){

--- a/rpg2d2/Assets/Resources/Scripts/PlayerContoroller.cs
+++ b/rpg2d2/Assets/Resources/Scripts/PlayerContoroller.cs
@@ -22,18 +22,18 @@ public class  PlayerContoroller : MonoBehaviour {
 
     public static List<int> my_items = new List<int>();
 	public static string player_name = "sample";
-
-    GameObject player_used;
+    
     GameObject touching;
 
-    void Awake(){
-		DontDestroyOnLoad(this);
-		player_used =  GameObject.Find ("Player_used");
-		if (player_used) {
-			player_used.GetComponent<Animator> ().enabled = true;
-			Destroy (GameObject.Find ("Player"));
-			player_used.name = "Player";
-		}
+    void Start(){
+        if (GameObject.Find("Player") != gameObject)
+        {
+            Destroy(gameObject);
+        }
+        else
+        {
+            DontDestroyOnLoad(this);
+        }
     }
 
     public void CheckObject()
@@ -53,7 +53,10 @@ public class  PlayerContoroller : MonoBehaviour {
 
     void OnCollisionEnter2D(Collision2D coll)
     {
-        touching = coll.gameObject;
+        if (coll.gameObject.GetComponent<OpenBoxContoroller>() != null || coll.gameObject.GetComponent<Messeage>() != null)
+        {
+            touching = coll.gameObject;
+        }
     }
 
     void OnCollisionExit2D(Collision2D coll)

--- a/rpg2d2/Assets/Resources/Scripts/TitleController.cs
+++ b/rpg2d2/Assets/Resources/Scripts/TitleController.cs
@@ -6,7 +6,7 @@ using System;
 
 public class TitleController : MonoBehaviour
 {
-
+    public string firstSceneName = "main";
     // Use this for initialization
     void Start()
     {
@@ -20,95 +20,11 @@ public class TitleController : MonoBehaviour
 
     public void NewGame()
     {
-        GameObject.Find("Player").name = "Player_used";
-        SceneManager.LoadScene("Scene/main");
+        GameObject.Find("GameManager").GetComponent<GameManager>().SceneChange(firstSceneName);
     }
 
     public void Continue()
     {
-        string json = PlayerPrefs.GetString("save");
-        Dictionary<string, string> data = JsonUtility.FromJson<Serialization<string, string>>(json).ToDictionary();
-
-        Dictionary<string, int> player_status = new Dictionary<string, int>();
-        Vector3 player_position = Vector3.zero;
-        string player_name = "";
-        string scene_name = "";
-        List<int> my_items = new List<int>();
-
-        foreach (string key in data.Keys)
-        {
-            switch (key)
-            {
-                case "player_status":
-                    player_status = JsonUtility.FromJson<Serialization<string, int>>(data[key]).ToDictionary();
-                    break;
-                case "player_position":
-                    player_position = JsonUtility.FromJson<Vector3>(data[key]);
-                    break;
-                case "player_name":
-                    player_name = data[key];
-                    break;
-                case "scene_name":
-                    scene_name = data[key];
-                    break;
-                case "my_items":
-                    my_items = JsonUtility.FromJson<Serialization<int>>(data[key]).ToList();
-                    break;
-            }
-        }
-        PlayerContoroller.player_status = player_status;
-        PlayerContoroller.player_name = player_name;
-        PlayerContoroller.my_items = my_items;
-        GameObject.Find("Player").GetComponent<Transform>().position = player_position;
-        GameObject.Find("Player").name = "Player_used";
-        SceneManager.LoadScene("Scene/" + scene_name);
-    }
-
-    // List<T>
-    [Serializable]
-    public class Serialization<T>
-    {
-        [SerializeField]
-        List<T> target;
-        public List<T> ToList() { return target; }
-
-        public Serialization(List<T> target)
-        {
-            this.target = target;
-        }
-    }
-
-    // Dictionary<TKey, TValue>
-    [Serializable]
-    public class Serialization<TKey, TValue> : ISerializationCallbackReceiver
-    {
-        [SerializeField]
-        List<TKey> keys;
-        [SerializeField]
-        List<TValue> values;
-
-        Dictionary<TKey, TValue> target;
-        public Dictionary<TKey, TValue> ToDictionary() { return target; }
-
-        public Serialization(Dictionary<TKey, TValue> target)
-        {
-            this.target = target;
-        }
-
-        public void OnBeforeSerialize()
-        {
-            keys = new List<TKey>(target.Keys);
-            values = new List<TValue>(target.Values);
-        }
-
-        public void OnAfterDeserialize()
-        {
-            var count = Math.Min(keys.Count, values.Count);
-            target = new Dictionary<TKey, TValue>(count);
-            for (var i = 0; i < count; ++i)
-            {
-                target.Add(keys[i], values[i]);
-            }
-        }
+        GameObject.Find("GameManager").GetComponent<GameManager>().Load();
     }
 }

--- a/rpg2d2/Assets/Scene/main.unity
+++ b/rpg2d2/Assets/Scene/main.unity
@@ -103460,6 +103460,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   item_id: 1
+  isOpen: 0
 --- !u!1 &1563556626 stripped
 GameObject:
   m_PrefabParentObject: {fileID: 1153730242980890, guid: 0ade75f8e504341dda070491143edfb4,

--- a/rpg2d2/Assets/Scene/title.unity
+++ b/rpg2d2/Assets/Scene/title.unity
@@ -382,6 +382,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: db304becbb5ea2646a65e8ab32382a4e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  firstSceneName: main
 --- !u!1 &853486354
 GameObject:
   m_ObjectHideFlags: 0
@@ -621,6 +622,46 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1493996533}
+--- !u!1 &1560720401
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1560720403}
+  - component: {fileID: 1560720402}
+  m_Layer: 0
+  m_Name: GameManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1560720402
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1560720401}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 56d5a2e722320f946b5347fa0d693507, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1560720403
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1560720401}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 42.679813, y: 45.8732, z: 84.29706}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1796780121
 Prefab:
   m_ObjectHideFlags: 0
@@ -1015,6 +1056,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: db304becbb5ea2646a65e8ab32382a4e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  firstSceneName: main
 --- !u!1 &2110910909
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
#58 #68 

新たに作成したGameManagerはTagにStrongBoxとつけられたオブジェクトのisOpenフラグとStatusWinowの表示状況をシーンを超えて保持します。
これを実現するためにGameManagerはDontDestroyOnLoadを実行しています

シーンをまたぐとき、特定の処理を行う必要があるのでシーンを変更する場合は
`GameObject.Find("GameManager").GetComponent<GameManager>().SceneChange(シーン名);`
を呼び出してください。シーン名にSceneフォルダの名前を入れる必要はありません。

DontDestroyOnLoadに関する処理を作る際今のPlayerの処理のやり方も検討しましたが、単純にすでに同じ名前のオブジェクトが作られていたら、自分をDestroyする処理にしました
その処理はPlayerにも適応しました。これでシーン遷移時Playerの名前をPlayer_usedにする必要はないはずです（バグがあったら速攻戻します）