### PR TITLE
fix #126

### DIFF
--- a/rpg2d2/Assets/Resources/Scripts/EnemiesData.cs
+++ b/rpg2d2/Assets/Resources/Scripts/EnemiesData.cs
@@ -73,4 +73,27 @@ public class EnemiesData : MonoBehaviour
         { "1", "もりのようせい",        "12", "0","8","4","1","0","1","1","5","2"},
         { "2", "ありせんし",            "7", "0","6","3","4","1","2","2","2","3"},
     };
+
+    public static string[,] GetMonsterList(string sceneName)
+    {
+        switch (sceneName)
+        {
+            case "map_west":
+                return westSceneMonsters;
+            case "map_east":
+                return eastSceneMonsters;
+            case "map_dendai2_1":
+                return dendai2_1SceneMonsters;
+            case "map_dendai2_2":
+                return dendai2_2SceneMonsters;
+            case "map_dendai1_1":
+                return dendai1_1SceneMonsters;
+            case "map_dendai1_2":
+                return dendai1_2SceneMonsters;
+            case "map_dendai1_3":
+                return dendai1_3SceneMonsters;
+            default:
+                return mainSceneMonsters;
+        }
+    }
 }

--- a/rpg2d2/Assets/Resources/Scripts/EnemyController.cs
+++ b/rpg2d2/Assets/Resources/Scripts/EnemyController.cs
@@ -25,7 +25,7 @@ public class EnemyController : MonoBehaviour {
 
     // Use this for initialization
     void Start() {
-        string[,] monster_list = GetMonsterList();
+        string[,] monster_list = EnemiesData.GetMonsterList(GameObject.Find("GameManager").GetComponent<GameManager>().prevSceneName);
         if (monster_num == -1)
         {
             monster_num = selectRandomMonster(monster_list);
@@ -43,31 +43,6 @@ public class EnemyController : MonoBehaviour {
         }
         setEnemyStatus(monster_list, monster_num);
         GameObject.Find("BattleField").transform.Find("LogModal").gameObject.GetComponent<LogController>().printText(new string[] { monster_name + "に" + encountStr[Random.Range(0, encountStr.Length - 1)] }).then(BattleManager.ToggleCommands); // 名前をlogにセット
-    }
-
-    string[,] GetMonsterList()
-    {
-        string prevSceneName = GameObject.Find("GameManager").GetComponent<GameManager>().prevSceneName;
-        switch (prevSceneName)
-        {
-            case "map_west":
-                 return EnemiesData.westSceneMonsters;
-            case "map_east":
-                return EnemiesData.eastSceneMonsters;
-            case "map_dendai2_1":
-                return EnemiesData.dendai2_1SceneMonsters;
-            case "map_dendai2_2":
-                return EnemiesData.dendai2_2SceneMonsters;
-            case "map_dendai1_1":
-                return EnemiesData.dendai1_1SceneMonsters;
-            case "map_dendai1_2":
-                return EnemiesData.dendai1_2SceneMonsters;
-            case "map_dendai1_3":
-                return EnemiesData.dendai1_3SceneMonsters;
-            default:
-                return EnemiesData.mainSceneMonsters;
-        }
-
     }
 
     /*

--- a/rpg2d2/Assets/Resources/Scripts/GameManager.cs
+++ b/rpg2d2/Assets/Resources/Scripts/GameManager.cs
@@ -101,6 +101,8 @@ public class GameManager : MonoBehaviour
                 PlayerContoroller.player_status = defaultStatus;
                 PlayerContoroller.my_items.Clear();
                 GameObject.Find("Player").transform.position = new Vector2(42, 50);
+                EnemyController.monster_name = null;
+                EnemyController.monster_num = -1;
                 isStateShow = false;
                 strongBoxes.Clear();
                 break;

--- a/rpg2d2/Assets/Resources/Scripts/SymbolEncountContoller.cs
+++ b/rpg2d2/Assets/Resources/Scripts/SymbolEncountContoller.cs
@@ -11,6 +11,10 @@ public class SymbolEncountContoller : MonoBehaviour
     // Use this for initialization
     void Start()
     {
+        if(EnemyController.monster_num == monster_num)
+        {
+            Destroy(gameObject);
+        }
         switch(EnemyController.monster_name) //戦闘終了後に呼び出したい処理を書く。逃げれない敵を指定すれば倒した後の処理となる。Endingへの遷移、倒した後の敵の命乞い等役立ててください。
         {
             case "THEラスボス": LogController.logController.printTextByFileName("test.txt").then(Callback1);

--- a/rpg2d2/Assets/Resources/Scripts/SymbolEncountContoller.cs
+++ b/rpg2d2/Assets/Resources/Scripts/SymbolEncountContoller.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class SymbolEncountContoller : MonoBehaviour
 {
@@ -10,14 +11,20 @@ public class SymbolEncountContoller : MonoBehaviour
     // Use this for initialization
     void Start()
     {
-        if (EnemyController.monster_num == monster_num)
+        switch(EnemyController.monster_name) //戦闘終了後に呼び出したい処理を書く。逃げれない敵を指定すれば倒した後の処理となる。Endingへの遷移、倒した後の敵の命乞い等役立ててください。
         {
-            LogController.logController.printText(new string[] { "やったー勝ったー" });
+            case "THEラスボス": LogController.logController.printTextByFileName("test.txt").then(Callback1);
+                    break;
         }
         if(GetComponent<Messeage>() == null)
         {
             Encount();
         }
+    }
+
+    void Callback1()
+    {
+        GameObject.Find("GameManager").GetComponent<GameManager>().SceneChange("ending", true);
     }
 
     // Update is called once per frame


### PR DESCRIPTION
SymbolEncountContoller.csの「ボス等を倒した後にログを表示する」処理部分をモンスター名に応じて変えられるようにしました。
ボスを倒した後に、そのボスにしゃべらせたり、エンディング画面への遷移に使うことができます。
ボスを倒した後にそのオブジェクトをdestroyしないと何度も戦えてしまうと思うので、その処理をswitch文でちまちまやるか、まとめて処理するかは分かりませんが今のところその処理は書いてません。意見を求めます。